### PR TITLE
Move Command (East only)

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,6 +19,10 @@ mix deps.get
 
 The `Toy Alchemist` is like the `Toy Robot` but with a special power revealed at just the right time. The Alchemist is here to help you learn Elixir. It hopes to pass on the potions, er powers.
 
+### Commands
+
+1. `MOVE` - Moves the `Alchemist` one space in the direction they are facing. It does not perform the move if the Alchemist can fall off of the Elixir Table.
+
 ## TESTING
 
 You can run the tasks with the standard mix command:

--- a/lib/toy_alchemist.ex
+++ b/lib/toy_alchemist.ex
@@ -1,10 +1,18 @@
 defmodule ToyAlchemist do
   @moduledoc """
-  Documentation for `ToyAlchemist`.
+  Performs the commands on the `Alchemist` and keeps track of them on the Elixir Table.
   """
 
   alias ToyAlchemist.Alchemist
 
+  @doc """
+  Moves an `Alchemist` one space in the facing direction.
+
+  ## Examples
+
+    iex> ToyAlchemist.move(%Alchemist{position: 1})
+    %Alchemist{position: 2}
+  """
   def move(%Alchemist{position: position} = alchemist) do
     %Alchemist{alchemist | position: position + 1}
   end

--- a/lib/toy_alchemist.ex
+++ b/lib/toy_alchemist.ex
@@ -3,16 +3,9 @@ defmodule ToyAlchemist do
   Documentation for `ToyAlchemist`.
   """
 
-  @doc """
-  Hello world.
+  alias ToyAlchemist.Alchemist
 
-  ## Examples
-
-      iex> ToyAlchemist.hello()
-      :world
-
-  """
-  def hello do
-    :world
+  def move(%Alchemist{position: position} = alchemist) do
+    %Alchemist{alchemist | position: position + 1}
   end
 end

--- a/lib/toy_alchemist/alchemist.ex
+++ b/lib/toy_alchemist/alchemist.ex
@@ -1,0 +1,7 @@
+defmodule ToyAlchemist.Alchemist do
+  defstruct [:position]
+
+  def new(position \\ 0) do
+    struct!(ToyAlchemist.Alchemist, position: position)
+  end
+end

--- a/lib/toy_alchemist/alchemist.ex
+++ b/lib/toy_alchemist/alchemist.ex
@@ -2,6 +2,6 @@ defmodule ToyAlchemist.Alchemist do
   defstruct [:position]
 
   def new(position \\ 0) do
-    struct!(ToyAlchemist.Alchemist, position: position)
+    struct!(__MODULE__, position: position)
   end
 end

--- a/test/toy_alchemist_test.exs
+++ b/test/toy_alchemist_test.exs
@@ -3,6 +3,8 @@ defmodule ToyAlchemistTest do
 
   alias ToyAlchemist.Alchemist
 
+  doctest ToyAlchemist
+
   describe "move/1" do
     test "increments the position of the alchemist" do
       alchemist = Alchemist.new(1)

--- a/test/toy_alchemist_test.exs
+++ b/test/toy_alchemist_test.exs
@@ -1,8 +1,13 @@
 defmodule ToyAlchemistTest do
   use ExUnit.Case
-  doctest ToyAlchemist
 
-  test "greets the world" do
-    assert ToyAlchemist.hello() == :world
+  alias ToyAlchemist.Alchemist
+
+  describe "move/1" do
+    test "increments the position of the alchemist" do
+      alchemist = Alchemist.new(1)
+
+      assert ToyAlchemist.move(alchemist) == %Alchemist{position: 2}
+    end
   end
 end


### PR DESCRIPTION
This PR implements the `MOVE` command for a new `Alchemist` struct in one direction ("east") (forward) only.

This assumes a single-axis position and only one "facing" direction of "east". The move command only increments the position by one.
