### PR TITLE
Move Command (X-Axis)

### DIFF
--- a/lib/toy_alchemist.ex
+++ b/lib/toy_alchemist.ex
@@ -6,14 +6,14 @@ defmodule ToyAlchemist do
   alias ToyAlchemist.Alchemist
 
   @doc """
-  Moves an `Alchemist` one space in the facing direction.
+  Moves an `Alchemist` one space in the east direction.
 
   ## Examples
 
-    iex> ToyAlchemist.move(%Alchemist{position: 1})
+    iex> ToyAlchemist.move_east(%Alchemist{position: 1})
     %Alchemist{position: 2}
   """
-  def move(%Alchemist{position: position} = alchemist) do
+  def move_east(%Alchemist{position: position} = alchemist) do
     %Alchemist{alchemist | position: position + 1}
   end
 end

--- a/lib/toy_alchemist.ex
+++ b/lib/toy_alchemist.ex
@@ -16,4 +16,16 @@ defmodule ToyAlchemist do
   def move_east(%Alchemist{position: position} = alchemist) do
     %Alchemist{alchemist | position: position + 1}
   end
+
+  @doc """
+  Moves an `Alchemist` one space in the west direction.
+
+  ## Examples
+
+    iex> ToyAlchemist.move_west(%Alchemist{position: 1})
+    %Alchemist{position: 0}
+  """
+  def move_west(%Alchemist{position: position} = alchemist) do
+    %Alchemist{alchemist | position: position - 1}
+  end
 end

--- a/test/toy_alchemist_test.exs
+++ b/test/toy_alchemist_test.exs
@@ -5,11 +5,11 @@ defmodule ToyAlchemistTest do
 
   doctest ToyAlchemist
 
-  describe "move/1" do
-    test "increments the position of the alchemist" do
+  describe "move_east/1" do
+    test "increments the east position of the alchemist" do
       alchemist = Alchemist.new(1)
 
-      assert ToyAlchemist.move(alchemist) == %Alchemist{position: 2}
+      assert ToyAlchemist.move_east(alchemist) == %Alchemist{position: 2}
     end
   end
 end

--- a/test/toy_alchemist_test.exs
+++ b/test/toy_alchemist_test.exs
@@ -11,5 +11,15 @@ defmodule ToyAlchemistTest do
 
       assert ToyAlchemist.move_east(alchemist) == %Alchemist{position: 2}
     end
+
+    test "chaining incrementing the east position" do
+      alchemist =
+        Alchemist.new(1)
+        |> ToyAlchemist.move_east()
+        |> ToyAlchemist.move_east()
+        |> ToyAlchemist.move_east()
+
+      assert alchemist == %Alchemist{position: 4}
+    end
   end
 end

--- a/test/toy_alchemist_test.exs
+++ b/test/toy_alchemist_test.exs
@@ -6,10 +6,10 @@ defmodule ToyAlchemistTest do
   doctest ToyAlchemist
 
   describe "move_east/1" do
-    test "increments the east position of the alchemist" do
-      alchemist = Alchemist.new(1)
+    test "increments the x-axis of the alchemist" do
+      alchemist = Alchemist.new(0)
 
-      assert ToyAlchemist.move_east(alchemist) == %Alchemist{position: 2}
+      assert ToyAlchemist.move_east(alchemist) == %Alchemist{position: 1}
     end
 
     test "chaining incrementing the east position" do
@@ -20,6 +20,24 @@ defmodule ToyAlchemistTest do
         |> ToyAlchemist.move_east()
 
       assert alchemist == %Alchemist{position: 4}
+    end
+  end
+
+  describe "move_west/1" do
+    test "decrements the x-axis of the alchemist" do
+      alchemist = Alchemist.new(0)
+
+      assert ToyAlchemist.move_west(alchemist) == %Alchemist{position: -1}
+    end
+
+    test "chaining incrementing the west position" do
+      alchemist =
+        Alchemist.new(-2)
+        |> ToyAlchemist.move_west()
+        |> ToyAlchemist.move_west()
+        |> ToyAlchemist.move_west()
+
+      assert alchemist == %Alchemist{position: -5}
     end
   end
 end


### PR DESCRIPTION
This PR improves the `MOVE` command by allowing the `Alchemist` to move in both a "forward" (East) direct as well as a "backward" (West) direction along the "x-axis".
