### PR TITLE
Move Command (All Directions)

### DIFF
--- a/lib/toy_alchemist.ex
+++ b/lib/toy_alchemist.ex
@@ -18,6 +18,18 @@ defmodule ToyAlchemist do
   end
 
   @doc """
+  Moves an `Alchemist` one space in the north direction.
+
+  ## Examples
+
+    iex> ToyAlchemist.move_north(%Alchemist{position: %{north: 1}})
+    %Alchemist{position: %{north: 2}}
+  """
+  def move_north(%Alchemist{position: %{north: north} = position} = alchemist) do
+    %Alchemist{alchemist | position: %{position | north: north + 1}}
+  end
+
+  @doc """
   Moves an `Alchemist` one space in the west direction.
 
   ## Examples

--- a/lib/toy_alchemist.ex
+++ b/lib/toy_alchemist.ex
@@ -10,11 +10,11 @@ defmodule ToyAlchemist do
 
   ## Examples
 
-    iex> ToyAlchemist.move_east(%Alchemist{position: 1})
-    %Alchemist{position: 2}
+    iex> ToyAlchemist.move_east(%Alchemist{position: %{east: 1}})
+    %Alchemist{position: %{east: 2}}
   """
-  def move_east(%Alchemist{position: position} = alchemist) do
-    %Alchemist{alchemist | position: position + 1}
+  def move_east(%Alchemist{position: %{east: east} = position} = alchemist) do
+    %Alchemist{alchemist | position: %{position | east: east + 1}}
   end
 
   @doc """
@@ -22,10 +22,10 @@ defmodule ToyAlchemist do
 
   ## Examples
 
-    iex> ToyAlchemist.move_west(%Alchemist{position: 1})
-    %Alchemist{position: 0}
+    iex> ToyAlchemist.move_west(%Alchemist{position: %{east: 1}})
+    %Alchemist{position: %{east: 0}}
   """
-  def move_west(%Alchemist{position: position} = alchemist) do
-    %Alchemist{alchemist | position: position - 1}
+  def move_west(%Alchemist{position: %{east: east} = position} = alchemist) do
+    %Alchemist{alchemist | position: %{position | east: east - 1}}
   end
 end

--- a/lib/toy_alchemist.ex
+++ b/lib/toy_alchemist.ex
@@ -30,6 +30,18 @@ defmodule ToyAlchemist do
   end
 
   @doc """
+  Moves an `Alchemist` one space in the south direction.
+
+  ## Examples
+
+    iex> ToyAlchemist.move_south(%Alchemist{position: %{north: -1}})
+    %Alchemist{position: %{north: -2}}
+  """
+  def move_south(%Alchemist{position: %{north: north} = position} = alchemist) do
+    %Alchemist{alchemist | position: %{position | north: north - 1}}
+  end
+
+  @doc """
   Moves an `Alchemist` one space in the west direction.
 
   ## Examples

--- a/lib/toy_alchemist/alchemist.ex
+++ b/lib/toy_alchemist/alchemist.ex
@@ -1,7 +1,7 @@
 defmodule ToyAlchemist.Alchemist do
   defstruct [:position]
 
-  def new(east \\ 0) do
-    struct!(__MODULE__, position: %{east: east})
+  def new(north \\ 0, east \\ 0) do
+    struct!(__MODULE__, position: %{north: north, east: east})
   end
 end

--- a/lib/toy_alchemist/alchemist.ex
+++ b/lib/toy_alchemist/alchemist.ex
@@ -1,7 +1,7 @@
 defmodule ToyAlchemist.Alchemist do
   defstruct [:position]
 
-  def new(position \\ 0) do
-    struct!(__MODULE__, position: position)
+  def new(east \\ 0) do
+    struct!(__MODULE__, position: %{east: east})
   end
 end

--- a/test/toy_alchemist_test.exs
+++ b/test/toy_alchemist_test.exs
@@ -7,37 +7,37 @@ defmodule ToyAlchemistTest do
 
   describe "move_east/1" do
     test "increments the east position of the alchemist" do
-      alchemist = Alchemist.new(0)
+      alchemist = Alchemist.new(0, 0)
 
-      assert ToyAlchemist.move_east(alchemist) == %Alchemist{position: %{east: 1}}
+      assert ToyAlchemist.move_east(alchemist) == %Alchemist{position: %{east: 1, north: 0}}
     end
 
     test "chaining incrementing the east position" do
       alchemist =
-        Alchemist.new(1)
+        Alchemist.new(0, 1)
         |> ToyAlchemist.move_east()
         |> ToyAlchemist.move_east()
         |> ToyAlchemist.move_east()
 
-      assert alchemist == %Alchemist{position: %{east: 4}}
+      assert alchemist == %Alchemist{position: %{east: 4, north: 0}}
     end
   end
 
   describe "move_west/1" do
     test "decrements the east position of the alchemist" do
-      alchemist = Alchemist.new(0)
+      alchemist = Alchemist.new(0, 0)
 
-      assert ToyAlchemist.move_west(alchemist) == %Alchemist{position: %{east: -1}}
+      assert ToyAlchemist.move_west(alchemist) == %Alchemist{position: %{east: -1, north: 0}}
     end
 
     test "chaining decrementing the east position" do
       alchemist =
-        Alchemist.new(-2)
+        Alchemist.new(0, -2)
         |> ToyAlchemist.move_west()
         |> ToyAlchemist.move_west()
         |> ToyAlchemist.move_west()
 
-      assert alchemist == %Alchemist{position: %{east: -5}}
+      assert alchemist == %Alchemist{position: %{east: -5, north: 0}}
     end
   end
 end

--- a/test/toy_alchemist_test.exs
+++ b/test/toy_alchemist_test.exs
@@ -41,6 +41,24 @@ defmodule ToyAlchemistTest do
     end
   end
 
+  describe "move_south/1" do
+    test "decrements the north position of the alchemist" do
+      alchemist = Alchemist.new(0, 0)
+
+      assert ToyAlchemist.move_south(alchemist) == %Alchemist{position: %{east: 0, north: -1}}
+    end
+
+    test "chaining decrementing the north position" do
+      alchemist =
+        Alchemist.new(-1, 0)
+        |> ToyAlchemist.move_south()
+        |> ToyAlchemist.move_south()
+        |> ToyAlchemist.move_south()
+
+      assert alchemist == %Alchemist{position: %{east: 0, north: -4}}
+    end
+  end
+
   describe "move_west/1" do
     test "decrements the east position of the alchemist" do
       alchemist = Alchemist.new(0, 0)

--- a/test/toy_alchemist_test.exs
+++ b/test/toy_alchemist_test.exs
@@ -6,10 +6,10 @@ defmodule ToyAlchemistTest do
   doctest ToyAlchemist
 
   describe "move_east/1" do
-    test "increments the x-axis of the alchemist" do
+    test "increments the east position of the alchemist" do
       alchemist = Alchemist.new(0)
 
-      assert ToyAlchemist.move_east(alchemist) == %Alchemist{position: 1}
+      assert ToyAlchemist.move_east(alchemist) == %Alchemist{position: %{east: 1}}
     end
 
     test "chaining incrementing the east position" do
@@ -19,25 +19,25 @@ defmodule ToyAlchemistTest do
         |> ToyAlchemist.move_east()
         |> ToyAlchemist.move_east()
 
-      assert alchemist == %Alchemist{position: 4}
+      assert alchemist == %Alchemist{position: %{east: 4}}
     end
   end
 
   describe "move_west/1" do
-    test "decrements the x-axis of the alchemist" do
+    test "decrements the east position of the alchemist" do
       alchemist = Alchemist.new(0)
 
-      assert ToyAlchemist.move_west(alchemist) == %Alchemist{position: -1}
+      assert ToyAlchemist.move_west(alchemist) == %Alchemist{position: %{east: -1}}
     end
 
-    test "chaining incrementing the west position" do
+    test "chaining decrementing the east position" do
       alchemist =
         Alchemist.new(-2)
         |> ToyAlchemist.move_west()
         |> ToyAlchemist.move_west()
         |> ToyAlchemist.move_west()
 
-      assert alchemist == %Alchemist{position: -5}
+      assert alchemist == %Alchemist{position: %{east: -5}}
     end
   end
 end

--- a/test/toy_alchemist_test.exs
+++ b/test/toy_alchemist_test.exs
@@ -23,6 +23,24 @@ defmodule ToyAlchemistTest do
     end
   end
 
+  describe "move_north/1" do
+    test "increments the north position of the alchemist" do
+      alchemist = Alchemist.new(0, 0)
+
+      assert ToyAlchemist.move_north(alchemist) == %Alchemist{position: %{east: 0, north: 1}}
+    end
+
+    test "chaining incrementing the north position" do
+      alchemist =
+        Alchemist.new(3, 0)
+        |> ToyAlchemist.move_north()
+        |> ToyAlchemist.move_north()
+        |> ToyAlchemist.move_north()
+
+      assert alchemist == %Alchemist{position: %{east: 0, north: 6}}
+    end
+  end
+
   describe "move_west/1" do
     test "decrements the east position of the alchemist" do
       alchemist = Alchemist.new(0, 0)


### PR DESCRIPTION
This PR improves the MOVE command by allowing the Alchemist to move in all directions, north, east, south, and west. Never eat soggy waffles.

This required the position to be a Map instead of an Integer so it could keep track of the forward and backward directions.