### PR TITLE
Introduce facing attribute

### DIFF
--- a/lib/toy_alchemist.ex
+++ b/lib/toy_alchemist.ex
@@ -6,50 +6,36 @@ defmodule ToyAlchemist do
   alias ToyAlchemist.{Alchemist, Position}
 
   @doc """
-  Moves an `Alchemist` one space in the east direction.
+  Moves an `Alchemist` one space in the direction the alchemist is currently facing.
 
   ## Examples
 
-    iex> ToyAlchemist.move_east(%Alchemist{position: %Position{east: 1}})
+    iex> ToyAlchemist.move(%Alchemist{position: %Position{east: 1}, facing: :east})
     %Alchemist{position: %Position{east: 2}}
   """
-  def move_east(%Alchemist{position: position} = alchemist) do
+  def move(%Alchemist{facing: facing} = alchemist) do
+    case facing do
+      :north -> alchemist |> move_north()
+      :east -> alchemist |> move_east()
+      :south -> alchemist |> move_south()
+      :west -> alchemist |> move_west()
+      _ -> alchemist
+    end
+  end
+
+  defp move_east(%Alchemist{position: position} = alchemist) do
     %Alchemist{alchemist | position: Position.move_east(position)}
   end
 
-  @doc """
-  Moves an `Alchemist` one space in the north direction.
-
-  ## Examples
-
-    iex> ToyAlchemist.move_north(%Alchemist{position: %Position{north: 1}})
-    %Alchemist{position: %Position{north: 2}}
-  """
-  def move_north(%Alchemist{position: position} = alchemist) do
+  defp move_north(%Alchemist{position: position} = alchemist) do
     %Alchemist{alchemist | position: Position.move_north(position)}
   end
 
-  @doc """
-  Moves an `Alchemist` one space in the south direction.
-
-  ## Examples
-
-    iex> ToyAlchemist.move_south(%Alchemist{position: %Position{north: -1}})
-    %Alchemist{position: %Position{north: -2}}
-  """
-  def move_south(%Alchemist{position: position} = alchemist) do
+  defp move_south(%Alchemist{position: position} = alchemist) do
     %Alchemist{alchemist | position: Position.move_south(position)}
   end
 
-  @doc """
-  Moves an `Alchemist` one space in the west direction.
-
-  ## Examples
-
-    iex> ToyAlchemist.move_west(%Alchemist{position: %Position{east: 1}})
-    %Alchemist{position: %Position{east: 0}}
-  """
-  def move_west(%Alchemist{position: position} = alchemist) do
+  defp move_west(%Alchemist{position: position} = alchemist) do
     %Alchemist{alchemist | position: Position.move_west(position)}
   end
 end

--- a/lib/toy_alchemist/alchemist.ex
+++ b/lib/toy_alchemist/alchemist.ex
@@ -1,9 +1,11 @@
 defmodule ToyAlchemist.Alchemist do
-  defstruct [:position]
+  defstruct [:facing, :position]
 
   alias ToyAlchemist.Position
 
-  def new(north \\ 0, east \\ 0) do
-    struct!(__MODULE__, position: Position.new(north, east))
+  def new(north \\ 0, east \\ 0, opts \\ []) do
+    facing = Keyword.get(opts, :facing, :north)
+
+    struct!(__MODULE__, facing: facing, position: Position.new(north, east))
   end
 end

--- a/test/toy_alchemist/alchemist_test.exs
+++ b/test/toy_alchemist/alchemist_test.exs
@@ -1,0 +1,18 @@
+defmodule ToyAlchemist.AlchemistTest do
+  use ExUnit.Case
+
+  alias ToyAlchemist.Alchemist
+
+  describe "new/1" do
+    test "returns an Alchemist with defaults" do
+      assert Alchemist.new() == %Alchemist{
+               position: %ToyAlchemist.Position{north: 0, east: 0, south: 0, west: 0},
+               facing: :north
+             }
+    end
+
+    test "allows to specify the facing direction" do
+      assert Alchemist.new(0, 0, facing: :south).facing == :south
+    end
+  end
+end

--- a/test/toy_alchemist_test.exs
+++ b/test/toy_alchemist_test.exs
@@ -1,77 +1,47 @@
 defmodule ToyAlchemistTest do
   use ExUnit.Case
 
-  alias ToyAlchemist.Alchemist
+  alias ToyAlchemist.{Alchemist, Position}
 
-  describe "move_east/1" do
-    test "increments the east position of the alchemist" do
-      alchemist = Alchemist.new(0, 0)
+  describe "move/1" do
+    test "when facining east, increments the east position" do
+      alchemist = Alchemist.new(0, 0, facing: :east) |> ToyAlchemist.move()
 
-      assert ToyAlchemist.move_east(alchemist).position.east == 1
+      assert alchemist.position == %Position{east: 1, west: -1, north: 0, south: 0}
     end
 
-    test "chaining incrementing the east position" do
+    test "when facining north, increments the north position" do
+      alchemist = Alchemist.new(0, 0, facing: :north) |> ToyAlchemist.move()
+
+      assert alchemist.position == %Position{east: 0, west: 0, north: 1, south: -1}
+    end
+
+    test "when facining south, increments the south position" do
+      alchemist = Alchemist.new(0, 0, facing: :south) |> ToyAlchemist.move()
+
+      assert alchemist.position == %Position{east: 0, west: 0, north: -1, south: 1}
+    end
+
+    test "when facining west, increments the west position" do
+      alchemist = Alchemist.new(0, 0, facing: :west) |> ToyAlchemist.move()
+
+      assert alchemist.position == %Position{east: -1, west: 1, north: 0, south: 0}
+    end
+
+    test "when facing a weird direction, it does not change the position" do
+      alchemist = Alchemist.new(1, 2, facing: :diagonal) |> ToyAlchemist.move()
+
+      assert alchemist.position == %Position{east: 2, west: -2, north: 1, south: -1}
+    end
+
+    test "chaining moves" do
       alchemist =
-        Alchemist.new(0, 1)
-        |> ToyAlchemist.move_east()
-        |> ToyAlchemist.move_east()
-        |> ToyAlchemist.move_east()
+        Alchemist.new(0, 1, facing: :east)
+        |> ToyAlchemist.move()
+        |> ToyAlchemist.move()
+        |> ToyAlchemist.move()
 
-      assert alchemist.position.east == 4
-    end
-  end
-
-  describe "move_north/1" do
-    test "increments the north position of the alchemist" do
-      alchemist = Alchemist.new(0, 0)
-
-      assert ToyAlchemist.move_north(alchemist).position.north == 1
-    end
-
-    test "chaining incrementing the north position" do
-      alchemist =
-        Alchemist.new(3, 0)
-        |> ToyAlchemist.move_north()
-        |> ToyAlchemist.move_north()
-        |> ToyAlchemist.move_north()
-
-      assert alchemist.position.north == 6
-    end
-  end
-
-  describe "move_south/1" do
-    test "decrements the north position of the alchemist" do
-      alchemist = Alchemist.new(0, 0)
-
-      assert ToyAlchemist.move_south(alchemist).position.north == -1
-    end
-
-    test "chaining decrementing the north position" do
-      alchemist =
-        Alchemist.new(-1, 0)
-        |> ToyAlchemist.move_south()
-        |> ToyAlchemist.move_south()
-        |> ToyAlchemist.move_south()
-
-      assert alchemist.position.north == -4
-    end
-  end
-
-  describe "move_west/1" do
-    test "decrements the east position of the alchemist" do
-      alchemist = Alchemist.new(0, 0)
-
-      assert ToyAlchemist.move_west(alchemist).position.east == -1
-    end
-
-    test "chaining decrementing the east position" do
-      alchemist =
-        Alchemist.new(0, -2)
-        |> ToyAlchemist.move_west()
-        |> ToyAlchemist.move_west()
-        |> ToyAlchemist.move_west()
-
-      assert alchemist.position.east == -5
+      assert alchemist.position == %Position{east: 4, west: -4, north: 0, south: 0}
     end
   end
 end


### PR DESCRIPTION
This PR introduces the `facing` parameter to an `Alchemist`'s struct.

This will now allow for a `move`command on an `Alchemist`that will move in the direction it is facing. It will also allow for future turn commands to be more easily implemented.

In addition, it will ignore the move command if an `Alchemist` tries to move in a weird direction.
