### PR TITLE
Turn commands

### DIFF
--- a/lib/toy_alchemist.ex
+++ b/lib/toy_alchemist.ex
@@ -23,6 +23,15 @@ defmodule ToyAlchemist do
     end
   end
 
+  @doc """
+  Turns an `Alchemist` one direction to the left and updates the facing direction to
+  the new direction it is using.
+
+  ## Examples
+
+    iex> ToyAlchemist.turn_left(%Alchemist{facing: :east})
+    %Alchemist{facing: :north}
+  """
   def turn_left(%Alchemist{facing: facing} = alchemist) do
     case facing do
       :north -> %Alchemist{alchemist | facing: :west}
@@ -33,6 +42,15 @@ defmodule ToyAlchemist do
     end
   end
 
+  @doc """
+  Turns an `Alchemist` one direction to the right and updates the facing direction to
+  the new direction it is using.
+
+  ## Examples
+
+    iex> ToyAlchemist.turn_right(%Alchemist{facing: :east})
+    %Alchemist{facing: :south}
+  """
   def turn_right(%Alchemist{facing: facing} = alchemist) do
     case facing do
       :north -> %Alchemist{alchemist | facing: :east}

--- a/lib/toy_alchemist.ex
+++ b/lib/toy_alchemist.ex
@@ -23,6 +23,16 @@ defmodule ToyAlchemist do
     end
   end
 
+  def turn_left(%Alchemist{facing: facing} = alchemist) do
+    case facing do
+      :north -> %Alchemist{alchemist | facing: :west}
+      :east -> %Alchemist{alchemist | facing: :north}
+      :south -> %Alchemist{alchemist | facing: :east}
+      :west -> %Alchemist{alchemist | facing: :south}
+      _ -> alchemist
+    end
+  end
+
   defp move_east(%Alchemist{position: position} = alchemist) do
     %Alchemist{alchemist | position: Position.move_east(position)}
   end

--- a/lib/toy_alchemist.ex
+++ b/lib/toy_alchemist.ex
@@ -33,6 +33,16 @@ defmodule ToyAlchemist do
     end
   end
 
+  def turn_right(%Alchemist{facing: facing} = alchemist) do
+    case facing do
+      :north -> %Alchemist{alchemist | facing: :east}
+      :east -> %Alchemist{alchemist | facing: :south}
+      :south -> %Alchemist{alchemist | facing: :west}
+      :west -> %Alchemist{alchemist | facing: :north}
+      _ -> alchemist
+    end
+  end
+
   defp move_east(%Alchemist{position: position} = alchemist) do
     %Alchemist{alchemist | position: Position.move_east(position)}
   end

--- a/test/toy_alchemist_test.exs
+++ b/test/toy_alchemist_test.exs
@@ -75,5 +75,57 @@ defmodule ToyAlchemistTest do
 
       assert alchemist.facing == :diagonal
     end
+
+    test "chaining turns" do
+      alchemist =
+        Alchemist.new(0, 1, facing: :east)
+        |> ToyAlchemist.turn_left()
+        |> ToyAlchemist.turn_left()
+        |> ToyAlchemist.turn_left()
+
+      assert alchemist.facing == :south
+    end
+  end
+
+  describe "turn_right/1" do
+    test "when facining east, it now faces south" do
+      alchemist = Alchemist.new(0, 0, facing: :east) |> ToyAlchemist.turn_right()
+
+      assert alchemist.facing == :south
+    end
+
+    test "when facining north, it now faces east" do
+      alchemist = Alchemist.new(0, 0, facing: :north) |> ToyAlchemist.turn_right()
+
+      assert alchemist.facing == :east
+    end
+
+    test "when facining west, it now faces north" do
+      alchemist = Alchemist.new(0, 0, facing: :west) |> ToyAlchemist.turn_right()
+
+      assert alchemist.facing == :north
+    end
+
+    test "when facining south, it now faces west" do
+      alchemist = Alchemist.new(0, 0, facing: :south) |> ToyAlchemist.turn_right()
+
+      assert alchemist.facing == :west
+    end
+
+    test "when facing a weird direction, it does not change the direction" do
+      alchemist = Alchemist.new(1, 2, facing: :diagonal) |> ToyAlchemist.turn_right()
+
+      assert alchemist.facing == :diagonal
+    end
+
+    test "chaining turns" do
+      alchemist =
+        Alchemist.new(0, 1, facing: :east)
+        |> ToyAlchemist.turn_right()
+        |> ToyAlchemist.turn_right()
+        |> ToyAlchemist.turn_right()
+
+      assert alchemist.facing == :north
+    end
   end
 end

--- a/test/toy_alchemist_test.exs
+++ b/test/toy_alchemist_test.exs
@@ -128,4 +128,28 @@ defmodule ToyAlchemistTest do
       assert alchemist.facing == :north
     end
   end
+
+  describe "chaining movement" do
+    test "ends up in the correct location and facing the correct direction" do
+      alchemist =
+        Alchemist.new(0, 0, facing: :north)
+        |> ToyAlchemist.move()
+        |> ToyAlchemist.turn_right()
+        |> ToyAlchemist.move()
+        |> ToyAlchemist.turn_left()
+        |> ToyAlchemist.move()
+        |> ToyAlchemist.move()
+        |> ToyAlchemist.turn_left()
+        |> ToyAlchemist.move()
+        |> ToyAlchemist.turn_right()
+        |> ToyAlchemist.turn_right()
+        |> ToyAlchemist.move()
+        |> ToyAlchemist.move()
+        |> ToyAlchemist.move()
+
+      assert alchemist.position.north == 3
+      assert alchemist.position.east == 3
+      assert alchemist.facing == :east
+    end
+  end
 end

--- a/test/toy_alchemist_test.exs
+++ b/test/toy_alchemist_test.exs
@@ -44,4 +44,36 @@ defmodule ToyAlchemistTest do
       assert alchemist.position == %Position{east: 4, west: -4, north: 0, south: 0}
     end
   end
+
+  describe "turn_left/1" do
+    test "when facining east, it now faces north" do
+      alchemist = Alchemist.new(0, 0, facing: :east) |> ToyAlchemist.turn_left()
+
+      assert alchemist.facing == :north
+    end
+
+    test "when facining north, it now faces west" do
+      alchemist = Alchemist.new(0, 0, facing: :north) |> ToyAlchemist.turn_left()
+
+      assert alchemist.facing == :west
+    end
+
+    test "when facining west, it now faces south" do
+      alchemist = Alchemist.new(0, 0, facing: :west) |> ToyAlchemist.turn_left()
+
+      assert alchemist.facing == :south
+    end
+
+    test "when facining south, it now faces east" do
+      alchemist = Alchemist.new(0, 0, facing: :south) |> ToyAlchemist.turn_left()
+
+      assert alchemist.facing == :east
+    end
+
+    test "when facing a weird direction, it does not change the direction" do
+      alchemist = Alchemist.new(1, 2, facing: :diagonal) |> ToyAlchemist.turn_left()
+
+      assert alchemist.facing == :diagonal
+    end
+  end
 end


### PR DESCRIPTION
This PR implements the `turn_left` and `turn_right` commands on the `ToyAlchemist`.

These methos only update the facing direction based on which way they turned.
