### PR TITLE
Valid movements in a Simulation + Reporting

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,6 +25,7 @@ The `Toy Alchemist` is like the `Toy Robot` but with a special power revealed at
 1. `LEFT` - Turns the `Alchemist` to the left of the direction they are facing.
 1. `RIGHT` - Turns the `Alchemist` to the right of the direction they are facing.
 1. `PLACE` - Places a new `Alchemist` at the specified position and facing the specified direction.
+1. `REPORT` - Reports on the position and direction of the `Alchemist`.
 
 ## TESTING
 

--- a/lib/toy_alchemist/simulation.ex
+++ b/lib/toy_alchemist/simulation.ex
@@ -7,6 +7,19 @@ defmodule ToyAlchemist.Simulation do
 
   alias ToyAlchemist.{Alchemist, Placement, Table}
 
+  @doc """
+  Simulates moving an `Alchemist` on a `Table` by one space in the direction it is facing.
+
+  It returns an `{:error, :out_of_bounds}` Tuple if the move would cause the `Alchemist` to fall
+  oof of the Table`.
+
+  ## Examples
+
+    iex> Simulation.move(%Simulation{alchemist: %Alchemist{position: %Position{north: 4, east: 2, south: -4, west: -3},
+    ...>                                                   facing: :east}, table: %Table{north_boundary: 4, east_boundary: 4}})
+    {:ok, %Simulation{alchemist: %Alchemist{position: %Position{north: 4, east: 3, south: -4, west: -3}, facing: :east},
+                      table: %Table{east_boundary: 4, north_boundary: 4}}}
+  """
   def move(%__MODULE__{alchemist: alchemist, table: table} = simulation) do
     moved = alchemist |> Alchemist.move()
 
@@ -34,6 +47,30 @@ defmodule ToyAlchemist.Simulation do
     else
       {:error, :invalid_placement}
     end
+  end
+
+  @doc """
+  Simulates turning an `Alchemist` on a `Table` to the left of where it is currently facing.
+
+  ## Examples
+
+    iex> Simulation.turn_left(%Simulation{alchemist: %Alchemist{facing: :east}})
+    {:ok, %Simulation{alchemist: %Alchemist{facing: :north}}}
+  """
+  def turn_left(%__MODULE__{alchemist: alchemist} = simulation) do
+    {:ok, %{simulation | alchemist: alchemist |> Alchemist.turn_left()}}
+  end
+
+  @doc """
+  Simulates turning an `Alchemist` on a `Table` to the right of where it is currently facing.
+
+  ## Examples
+
+    iex> Simulation.turn_right(%Simulation{alchemist: %Alchemist{facing: :east}})
+    {:ok, %Simulation{alchemist: %Alchemist{facing: :south}}}
+  """
+  def turn_right(%__MODULE__{alchemist: alchemist} = simulation) do
+    {:ok, %{simulation | alchemist: alchemist |> Alchemist.turn_right()}}
   end
 
   defp new(alchemist, table) do

--- a/lib/toy_alchemist/simulation.ex
+++ b/lib/toy_alchemist/simulation.ex
@@ -50,6 +50,16 @@ defmodule ToyAlchemist.Simulation do
   end
 
   @doc """
+  Returns the `Alchemist` of the `Simulation` so it can be reported on.
+
+  ## Examples
+
+    iex> Simulation.report(%Simulation{alchemist: %Alchemist{facing: :north}})
+    %Alchemist{facing: :north}
+  """
+  def report(%__MODULE__{alchemist: alchemist}), do: alchemist
+
+  @doc """
   Simulates turning an `Alchemist` on a `Table` to the left of where it is currently facing.
 
   ## Examples

--- a/lib/toy_alchemist/simulation.ex
+++ b/lib/toy_alchemist/simulation.ex
@@ -7,6 +7,16 @@ defmodule ToyAlchemist.Simulation do
 
   alias ToyAlchemist.{Alchemist, Placement, Table}
 
+  def move(%__MODULE__{alchemist: alchemist, table: table} = simulation) do
+    moved = alchemist |> Alchemist.move()
+
+    if Table.valid_position?(table, moved.position) do
+      {:ok, %{simulation | alchemist: moved}}
+    else
+      {:error, :out_of_bounds}
+    end
+  end
+
   @doc """
   Simulates placing an `Alchemist` on a `Table` at the specified `Placement`.
 
@@ -16,8 +26,8 @@ defmodule ToyAlchemist.Simulation do
     {:ok, %Simulation{alchemist: %Alchemist{position: %Position{north: 0, east: 2, south: 0, west: -2}, facing: :north},
                       table: %Table{east_boundary: 4, north_boundary: 4}}}
   """
-  def place(%Table{} = table, %Placement{north: north, east: east, facing: facing}) do
-    if Table.valid_position?(table, north, east) do
+  def place(%Table{} = table, %Placement{north: north, east: east, facing: facing} = placement) do
+    if Table.valid_position?(table, placement) do
       alchemist = Alchemist.new(north, east, facing: facing)
 
       {:ok, new(alchemist, table)}

--- a/lib/toy_alchemist/table.ex
+++ b/lib/toy_alchemist/table.ex
@@ -22,13 +22,12 @@ defmodule ToyAlchemist.Table do
 
   ## Examples
 
-    iex> Table.valid_position?(%Table{east_boundary: 4, north_boundary: 3}, 2, 2)
+    iex> Table.valid_position?(%Table{east_boundary: 4, north_boundary: 3}, %{north: 2, east: 2})
     true
   """
   def valid_position?(
         %__MODULE__{north_boundary: north_boundary, east_boundary: east_boundary},
-        north_position,
-        east_position
+        %{north: north_position, east: east_position}
       ) do
     within_boundary?(north_boundary, north_position) &&
       within_boundary?(east_boundary, east_position)

--- a/test/toy_alchemist/simulation_test.exs
+++ b/test/toy_alchemist/simulation_test.exs
@@ -67,4 +67,38 @@ defmodule ToyAlchemist.SimulationTest do
       assert {:error, :invalid_placement} = Simulation.place(table, Placement.new(5, 2))
     end
   end
+
+  describe "turn_left/1" do
+    setup do
+      table = Table.new(4, 4)
+      placement = Placement.new(0, 0, :north)
+
+      {:ok, simulation} = Simulation.place(table, placement)
+
+      [simulation: simulation, table: table]
+    end
+
+    test "a simulation is returned with the alchemist in the updated direction",
+         %{simulation: simulation} do
+      assert {:ok, %{alchemist: alchemist}} = Simulation.turn_left(simulation)
+      assert alchemist.facing == :west
+    end
+  end
+
+  describe "turn_right/1" do
+    setup do
+      table = Table.new(4, 4)
+      placement = Placement.new(0, 0, :north)
+
+      {:ok, simulation} = Simulation.place(table, placement)
+
+      [simulation: simulation, table: table]
+    end
+
+    test "a simulation is returned with the alchemist in the updated direction",
+         %{simulation: simulation} do
+      assert {:ok, %{alchemist: alchemist}} = Simulation.turn_right(simulation)
+      assert alchemist.facing == :east
+    end
+  end
 end

--- a/test/toy_alchemist/simulation_test.exs
+++ b/test/toy_alchemist/simulation_test.exs
@@ -68,6 +68,23 @@ defmodule ToyAlchemist.SimulationTest do
     end
   end
 
+  describe "report/1" do
+    setup do
+      table = Table.new(4, 4)
+      placement = Placement.new(0, 0, :north)
+
+      {:ok, simulation} = Simulation.place(table, placement)
+
+      [simulation: simulation]
+    end
+
+    test "an alchemist is returned so it can be reported on",
+         %{simulation: simulation} do
+      assert alchemist = Simulation.report(simulation)
+      assert alchemist == simulation.alchemist
+    end
+  end
+
   describe "turn_left/1" do
     setup do
       table = Table.new(4, 4)
@@ -75,7 +92,7 @@ defmodule ToyAlchemist.SimulationTest do
 
       {:ok, simulation} = Simulation.place(table, placement)
 
-      [simulation: simulation, table: table]
+      [simulation: simulation]
     end
 
     test "a simulation is returned with the alchemist in the updated direction",
@@ -92,7 +109,7 @@ defmodule ToyAlchemist.SimulationTest do
 
       {:ok, simulation} = Simulation.place(table, placement)
 
-      [simulation: simulation, table: table]
+      [simulation: simulation]
     end
 
     test "a simulation is returned with the alchemist in the updated direction",

--- a/test/toy_alchemist/simulation_test.exs
+++ b/test/toy_alchemist/simulation_test.exs
@@ -5,6 +5,33 @@ defmodule ToyAlchemist.SimulationTest do
 
   doctest Simulation
 
+  describe "move/1" do
+    setup do
+      table = Table.new(4, 4)
+      placement = Placement.new(0, 0, :north)
+
+      {:ok, simulation} = Simulation.place(table, placement)
+
+      [simulation: simulation, table: table]
+    end
+
+    test "when moving to a valid position, a simulation is returned with the alchemist in the updated position",
+         %{simulation: simulation} do
+      assert {:ok, %{alchemist: alchemist}} = Simulation.move(simulation)
+      assert alchemist.facing == :north
+      assert alchemist.position.east == 0
+      assert alchemist.position.north == 1
+    end
+
+    test "when moving out of bounds, an error is returned", %{table: table} do
+      placement = Placement.new(4, 0, :north)
+
+      {:ok, simulation} = Simulation.place(table, placement)
+
+      assert {:error, :out_of_bounds} = Simulation.move(simulation)
+    end
+  end
+
   describe "place/2" do
     setup do
       [placement: Placement.new(0, 0, :north), table: Table.new(4, 4)]

--- a/test/toy_alchemist/table_test.exs
+++ b/test/toy_alchemist/table_test.exs
@@ -11,15 +11,15 @@ defmodule ToyAlchemist.TableTest do
     end
 
     test "returns true when the position is within the table boundaries", %{table: table} do
-      assert Table.valid_position?(table, 2, 3)
+      assert Table.valid_position?(table, %{north: 2, east: 3})
     end
 
     test "returns false when the position is below the boundary", %{table: table} do
-      refute Table.valid_position?(table, 2, -1)
+      refute Table.valid_position?(table, %{north: 2, east: -1})
     end
 
     test "returns false when the position is above the boundary", %{table: table} do
-      refute Table.valid_position?(table, 5, 3)
+      refute Table.valid_position?(table, %{north: 5, east: 3})
     end
   end
 end


### PR DESCRIPTION
This PR validates movement within a `Simulation`.

It ensures that a `move` command would result in an `{:error, :out_of_bounds}` Tuple if it would throw the `Alchemist` off of the Elixir Table.

In addition, this adds the `REPORT` command as it just returns the `Alchemist` so the calling client can report on it.
