### PR TITLE
Potion Interpreter

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ mix deps.get
 
 The `Toy Alchemist` is like the `Toy Robot` but with a special power revealed at just the right time. The Alchemist is here to help you learn Elixir. It hopes to pass on the potions, er powers.
 
-### Commands
+### Potions
 
 1. `MOVE` - Moves the `Alchemist` one space in the direction they are facing. It does not perform the move if the Alchemist can fall off of the Elixir Table.
 1. `LEFT` - Turns the `Alchemist` to the left of the direction they are facing.

--- a/lib/toy_alchemist/potion_interpreter.ex
+++ b/lib/toy_alchemist/potion_interpreter.ex
@@ -1,4 +1,16 @@
 defmodule ToyAlchemist.PotionInterpreter do
+  @moduledoc """
+  Interprets a list of text based potions.
+  """
+
+  @doc """
+  Enumerates through a list of text based potions and converts them into Wizardry instructions.
+
+  ## Examples
+
+    iex> PotionInterpreter.interpret(["PLACE 0,3,SOUTH", "MOVE", "REPORT"])
+    [{:place, [north: 0, east: 3, facing: :south]}, {:move}, {:report}]
+  """
   def interpret(potions), do: potions |> Enum.map(&interpret_potion/1)
 
   defp interpret_potion("LEFT"), do: {:turn_left}

--- a/lib/toy_alchemist/potion_interpreter.ex
+++ b/lib/toy_alchemist/potion_interpreter.ex
@@ -1,0 +1,21 @@
+defmodule ToyAlchemist.PotionInterpreter do
+  def interpret(potions), do: potions |> Enum.map(&interpret_potion/1)
+
+  defp interpret_potion("LEFT"), do: {:turn_left}
+  defp interpret_potion("MOVE"), do: {:move}
+  defp interpret_potion("PLACE " <> args), do: {:place, interpret_potion_arguments(:place, args)}
+  defp interpret_potion("REPORT"), do: {:report}
+  defp interpret_potion("RIGHT"), do: {:turn_right}
+
+  defp interpret_potion_arguments(:place, args) do
+    arguments =
+      ~r/^(?<north>\d+),(?<east>\d+),(?<facing>NORTH|EAST|SOUTH|WEST)$/
+      |> Regex.named_captures(args)
+
+    [
+      north: arguments["north"] |> String.to_integer(),
+      east: arguments["east"] |> String.to_integer(),
+      facing: arguments["facing"] |> String.downcase() |> String.to_atom()
+    ]
+  end
+end

--- a/lib/toy_alchemist/potion_interpreter.ex
+++ b/lib/toy_alchemist/potion_interpreter.ex
@@ -6,7 +6,7 @@ defmodule ToyAlchemist.PotionInterpreter do
 
   defp interpret_potion("PLACE " <> args = potion) do
     case interpret_potion_arguments(:place, args) do
-      [] -> {:invalid, potion}
+      :invalid_arguments -> {:invalid, potion}
       arguments -> {:place, arguments}
     end
   end
@@ -25,7 +25,7 @@ defmodule ToyAlchemist.PotionInterpreter do
     |> parse_potion_arguments(:place)
   end
 
-  defp parse_potion_arguments(nil, _potion), do: []
+  defp parse_potion_arguments(nil, _potion), do: :invalid_arguments
 
   defp parse_potion_arguments(args, :place) do
     [

--- a/lib/toy_alchemist/potion_interpreter.ex
+++ b/lib/toy_alchemist/potion_interpreter.ex
@@ -3,19 +3,35 @@ defmodule ToyAlchemist.PotionInterpreter do
 
   defp interpret_potion("LEFT"), do: {:turn_left}
   defp interpret_potion("MOVE"), do: {:move}
-  defp interpret_potion("PLACE " <> args), do: {:place, interpret_potion_arguments(:place, args)}
+
+  defp interpret_potion("PLACE " <> args = potion) do
+    case interpret_potion_arguments(:place, args) do
+      [] -> {:invalid, potion}
+      arguments -> {:place, arguments}
+    end
+  end
+
   defp interpret_potion("REPORT"), do: {:report}
   defp interpret_potion("RIGHT"), do: {:turn_right}
 
-  defp interpret_potion_arguments(:place, args) do
-    arguments =
-      ~r/^(?<north>\d+),(?<east>\d+),(?<facing>NORTH|EAST|SOUTH|WEST)$/
-      |> Regex.named_captures(args)
+  defp interpret_potion(invalid_potion),
+    do: {:invalid, interpret_potion_arguments(:invalid, invalid_potion)}
 
+  defp interpret_potion_arguments(:invalid, args), do: args
+
+  defp interpret_potion_arguments(:place, args) do
+    ~r/^(?<north>\d+),(?<east>\d+),(?<facing>NORTH|EAST|SOUTH|WEST)$/
+    |> Regex.named_captures(args)
+    |> parse_potion_arguments(:place)
+  end
+
+  defp parse_potion_arguments(nil, _potion), do: []
+
+  defp parse_potion_arguments(args, :place) do
     [
-      north: arguments["north"] |> String.to_integer(),
-      east: arguments["east"] |> String.to_integer(),
-      facing: arguments["facing"] |> String.downcase() |> String.to_atom()
+      north: args["north"] |> String.to_integer(),
+      east: args["east"] |> String.to_integer(),
+      facing: args["facing"] |> String.downcase() |> String.to_atom()
     ]
   end
 end

--- a/test/toy_alchemist/potion_interpreter_test.exs
+++ b/test/toy_alchemist/potion_interpreter_test.exs
@@ -35,5 +35,21 @@ defmodule ToyAlchemist.PotionInterpreterTest do
     test "with an invalid potion, returns an invalid tuple" do
       assert PotionInterpreter.interpret(["BLAH"]) == [{:invalid, "BLAH"}]
     end
+
+    test "interprets several potions" do
+      potions = [
+        "PLACE 1,3,EAST",
+        "MOVE",
+        "BLAH",
+        "REPORT"
+      ]
+
+      assert PotionInterpreter.interpret(potions) == [
+               {:place, [north: 1, east: 3, facing: :east]},
+               {:move},
+               {:invalid, "BLAH"},
+               {:report}
+             ]
+    end
   end
 end

--- a/test/toy_alchemist/potion_interpreter_test.exs
+++ b/test/toy_alchemist/potion_interpreter_test.exs
@@ -3,6 +3,8 @@ defmodule ToyAlchemist.PotionInterpreterTest do
 
   alias ToyAlchemist.PotionInterpreter
 
+  doctest PotionInterpreter
+
   describe "interpret/1" do
     test "with a MOVE potion, returns a move tuple" do
       assert PotionInterpreter.interpret(["MOVE"]) == [{:move}]

--- a/test/toy_alchemist/potion_interpreter_test.exs
+++ b/test/toy_alchemist/potion_interpreter_test.exs
@@ -1,0 +1,29 @@
+defmodule ToyAlchemist.PotionInterpreterTest do
+  use ExUnit.Case
+
+  alias ToyAlchemist.PotionInterpreter
+
+  describe "interpret/1" do
+    test "with a MOVE potion, returns a move tuple" do
+      assert PotionInterpreter.interpret(["MOVE"]) == [{:move}]
+    end
+
+    test "with a LEFT potion, returns a turn left tuple" do
+      assert PotionInterpreter.interpret(["LEFT"]) == [{:turn_left}]
+    end
+
+    test "with a RIGHT potion, returns a turn right tuple" do
+      assert PotionInterpreter.interpret(["RIGHT"]) == [{:turn_right}]
+    end
+
+    test "with a REPORT potion, returns a report tuple" do
+      assert PotionInterpreter.interpret(["REPORT"]) == [{:report}]
+    end
+
+    test "with a PLACE potion, returns a place tuple with parameters" do
+      assert PotionInterpreter.interpret(["PLACE 1,2,NORTH"]) == [
+               {:place, [north: 1, east: 2, facing: :north]}
+             ]
+    end
+  end
+end

--- a/test/toy_alchemist/potion_interpreter_test.exs
+++ b/test/toy_alchemist/potion_interpreter_test.exs
@@ -25,5 +25,15 @@ defmodule ToyAlchemist.PotionInterpreterTest do
                {:place, [north: 1, east: 2, facing: :north]}
              ]
     end
+
+    test "with a PLACE potion with invalid arguments, returns an invalid tuple" do
+      potion = "PLACE 8,-,EAST"
+
+      assert PotionInterpreter.interpret([potion]) == [{:invalid, potion}]
+    end
+
+    test "with an invalid potion, returns an invalid tuple" do
+      assert PotionInterpreter.interpret(["BLAH"]) == [{:invalid, "BLAH"}]
+    end
   end
 end


### PR DESCRIPTION
This PR creates the `PotionInterpreter` which can read a binary representation of a "potion" and return the data represented as a Tuple.

It handles the following potions:

* `PLACE`
* `MOVE`
* `LEFT`
* `RIGHT`
* `REPORT`

It also returns an `{:invalid, potion}` when the potion could not be interpreted.
