### PR TITLE
Wizard

### DIFF
--- a/lib/toy_alchemist/placement.ex
+++ b/lib/toy_alchemist/placement.ex
@@ -16,4 +16,14 @@ defmodule ToyAlchemist.Placement do
   def new(north \\ 0, east \\ 0, facing \\ :north) do
     struct!(__MODULE__, north: north, east: east, facing: facing)
   end
+
+  @doc """
+  Populates a new `Placement` struct with the specified attributes in a Map.
+
+  ## Examples
+
+    iex> Placement.from_map(%{north: 3, east: 4})
+    %Placement{north: 3, east: 4, facing: :north}
+  """
+  def from_map(attrs), do: struct!(__MODULE__, attrs)
 end

--- a/lib/toy_alchemist/sorcerer.ex
+++ b/lib/toy_alchemist/sorcerer.ex
@@ -1,4 +1,4 @@
-defmodule ToyAlchemist.PotionInterpreter do
+defmodule ToyAlchemist.Sorcerer do
   @moduledoc """
   Interprets a list of text based potions.
   """
@@ -8,7 +8,7 @@ defmodule ToyAlchemist.PotionInterpreter do
 
   ## Examples
 
-    iex> PotionInterpreter.interpret(["PLACE 0,3,SOUTH", "MOVE", "REPORT"])
+    iex> Sorcerer.interpret(["PLACE 0,3,SOUTH", "MOVE", "REPORT"])
     [{:place, [north: 0, east: 3, facing: :south]}, {:move}, {:report}]
   """
   def interpret(potions), do: potions |> Enum.map(&interpret_potion/1)

--- a/lib/toy_alchemist/wizard.ex
+++ b/lib/toy_alchemist/wizard.ex
@@ -1,0 +1,53 @@
+defmodule ToyAlchemist.Wizard do
+  alias ToyAlchemist.{Placement, Simulation, Table}
+
+  def cast_spell([{:place, placement} | remaining]) do
+    case Simulation.place(default_table(), Placement.from_map(placement)) do
+      {:ok, simulation} -> cast_spell(remaining, simulation)
+      {:error, :invalid_placement} -> cast_spell(remaining)
+    end
+  end
+
+  def cast_spell([_unknown | remaining]), do: cast_spell(remaining)
+  def cast_spell([]), do: nil
+
+  def cast_spell([{:invalid, _potion} | remaining], simulation),
+    do: cast_spell(remaining, simulation)
+
+  def cast_spell([:move | remaining], simulation) do
+    case Simulation.move(simulation) do
+      {:ok, simulation} -> cast_spell(remaining, simulation)
+      {:error, :out_of_bounds} -> cast_spell(remaining, simulation)
+    end
+  end
+
+  def cast_spell([:report | remaining], simulation) do
+    simulation |> Simulation.report() |> report_on()
+    cast_spell(remaining, simulation)
+  end
+
+  def cast_spell([:turn_left | remaining], simulation) do
+    {:ok, simulation} = simulation |> Simulation.turn_left()
+    cast_spell(remaining, simulation)
+  end
+
+  def cast_spell([:turn_right | remaining], simulation) do
+    {:ok, simulation} = simulation |> Simulation.turn_right()
+    cast_spell(remaining, simulation)
+  end
+
+  def cast_spell([], simulation), do: simulation
+
+  defp default_table(opts \\ []) do
+    north_boundary = Keyword.get(opts, :north_boundary, 4)
+    east_boundary = Keyword.get(opts, :east_boundary, 4)
+
+    Table.new(north_boundary, east_boundary)
+  end
+
+  defp report_on(%{position: %{north: north, east: east}, facing: facing}) do
+    direction = facing |> to_string() |> String.upcase()
+
+    IO.puts("The alchemist is at (#{north}, #{east}) and facing #{direction}")
+  end
+end

--- a/lib/toy_alchemist/wizard.ex
+++ b/lib/toy_alchemist/wizard.ex
@@ -1,6 +1,22 @@
 defmodule ToyAlchemist.Wizard do
+  @moduledoc """
+  Performs a list of potions that were interpreted from a `PositionInterpreter`.
+  """
+
   alias ToyAlchemist.{Placement, Simulation, Table}
 
+  @doc """
+  Enumerates through a list of potions that were converted into Wizardry instructions
+  and performs those potions within a `Simulation`.
+
+  After all of the valid potions are casted, the resulting `Simulation` is returned.
+
+  ## Examples
+
+    iex> Wizard.cast_spell([{:place, [north: 1, east: 3, facing: :north]}, :move, :turn_left, :move])
+    %Simulation{alchemist: %ToyAlchemist.Alchemist{position: %ToyAlchemist.Position{north: 2, east: 2, south: -2, west: -2}, facing: :west},
+                table: %ToyAlchemist.Table{north_boundary: 4, east_boundary: 4}}
+  """
   def cast_spell([{:place, placement} | remaining]) do
     case Simulation.place(default_table(), Placement.from_map(placement)) do
       {:ok, simulation} -> cast_spell(remaining, simulation)
@@ -11,32 +27,32 @@ defmodule ToyAlchemist.Wizard do
   def cast_spell([_unknown | remaining]), do: cast_spell(remaining)
   def cast_spell([]), do: nil
 
-  def cast_spell([{:invalid, _potion} | remaining], simulation),
+  defp cast_spell([{:invalid, _potion} | remaining], simulation),
     do: cast_spell(remaining, simulation)
 
-  def cast_spell([:move | remaining], simulation) do
+  defp cast_spell([:move | remaining], simulation) do
     case Simulation.move(simulation) do
       {:ok, simulation} -> cast_spell(remaining, simulation)
       {:error, :out_of_bounds} -> cast_spell(remaining, simulation)
     end
   end
 
-  def cast_spell([:report | remaining], simulation) do
+  defp cast_spell([:report | remaining], simulation) do
     simulation |> Simulation.report() |> report_on()
     cast_spell(remaining, simulation)
   end
 
-  def cast_spell([:turn_left | remaining], simulation) do
+  defp cast_spell([:turn_left | remaining], simulation) do
     {:ok, simulation} = simulation |> Simulation.turn_left()
     cast_spell(remaining, simulation)
   end
 
-  def cast_spell([:turn_right | remaining], simulation) do
+  defp cast_spell([:turn_right | remaining], simulation) do
     {:ok, simulation} = simulation |> Simulation.turn_right()
     cast_spell(remaining, simulation)
   end
 
-  def cast_spell([], simulation), do: simulation
+  defp cast_spell([], simulation), do: simulation
 
   defp default_table(opts \\ []) do
     north_boundary = Keyword.get(opts, :north_boundary, 4)

--- a/test/toy_alchemist/sorcerer_test.exs
+++ b/test/toy_alchemist/sorcerer_test.exs
@@ -1,29 +1,29 @@
-defmodule ToyAlchemist.PotionInterpreterTest do
+defmodule ToyAlchemist.SorcererTest do
   use ExUnit.Case
 
-  alias ToyAlchemist.PotionInterpreter
+  alias ToyAlchemist.Sorcerer
 
-  doctest PotionInterpreter
+  doctest Sorcerer
 
   describe "interpret/1" do
     test "with a MOVE potion, returns a move tuple" do
-      assert PotionInterpreter.interpret(["MOVE"]) == [{:move}]
+      assert Sorcerer.interpret(["MOVE"]) == [{:move}]
     end
 
     test "with a LEFT potion, returns a turn left tuple" do
-      assert PotionInterpreter.interpret(["LEFT"]) == [{:turn_left}]
+      assert Sorcerer.interpret(["LEFT"]) == [{:turn_left}]
     end
 
     test "with a RIGHT potion, returns a turn right tuple" do
-      assert PotionInterpreter.interpret(["RIGHT"]) == [{:turn_right}]
+      assert Sorcerer.interpret(["RIGHT"]) == [{:turn_right}]
     end
 
     test "with a REPORT potion, returns a report tuple" do
-      assert PotionInterpreter.interpret(["REPORT"]) == [{:report}]
+      assert Sorcerer.interpret(["REPORT"]) == [{:report}]
     end
 
     test "with a PLACE potion, returns a place tuple with parameters" do
-      assert PotionInterpreter.interpret(["PLACE 1,2,NORTH"]) == [
+      assert Sorcerer.interpret(["PLACE 1,2,NORTH"]) == [
                {:place, [north: 1, east: 2, facing: :north]}
              ]
     end
@@ -31,11 +31,11 @@ defmodule ToyAlchemist.PotionInterpreterTest do
     test "with a PLACE potion with invalid arguments, returns an invalid tuple" do
       potion = "PLACE 8,-,EAST"
 
-      assert PotionInterpreter.interpret([potion]) == [{:invalid, potion}]
+      assert Sorcerer.interpret([potion]) == [{:invalid, potion}]
     end
 
     test "with an invalid potion, returns an invalid tuple" do
-      assert PotionInterpreter.interpret(["BLAH"]) == [{:invalid, "BLAH"}]
+      assert Sorcerer.interpret(["BLAH"]) == [{:invalid, "BLAH"}]
     end
 
     test "interprets several potions" do
@@ -46,7 +46,7 @@ defmodule ToyAlchemist.PotionInterpreterTest do
         "REPORT"
       ]
 
-      assert PotionInterpreter.interpret(potions) == [
+      assert Sorcerer.interpret(potions) == [
                {:place, [north: 1, east: 3, facing: :east]},
                {:move},
                {:invalid, "BLAH"},

--- a/test/toy_alchemist/wizard_test.exs
+++ b/test/toy_alchemist/wizard_test.exs
@@ -5,6 +5,8 @@ defmodule ToyAlchemist.WizardTest do
 
   alias ToyAlchemist.{Simulation, Wizard}
 
+  doctest Wizard
+
   describe "cast_spell/1" do
     test "with a place potion returns a simulation with the alchemist placed" do
       assert %Simulation{alchemist: alchemist} =

--- a/test/toy_alchemist/wizard_test.exs
+++ b/test/toy_alchemist/wizard_test.exs
@@ -1,0 +1,104 @@
+defmodule ToyAlchemist.WizardTest do
+  use ExUnit.Case
+
+  import ExUnit.CaptureIO
+
+  alias ToyAlchemist.{Simulation, Wizard}
+
+  describe "cast_spell/1" do
+    test "with a place potion returns a simulation with the alchemist placed" do
+      assert %Simulation{alchemist: alchemist} =
+               Wizard.cast_spell([{:place, [north: 1, east: 3, facing: :east]}])
+
+      assert alchemist.position.north == 1
+      assert alchemist.position.east == 3
+      assert alchemist.facing == :east
+    end
+
+    test "with a place potion returns a simulation with a default table" do
+      assert %Simulation{table: table} =
+               Wizard.cast_spell([{:place, [north: 4, east: 3, facing: :west]}])
+
+      assert table.north_boundary == 4
+      assert table.east_boundary == 4
+    end
+
+    test "with a place potion and a placement outside the boundary ignores the error" do
+      refute Wizard.cast_spell([{:place, [north: -1, east: 3, facing: :south]}])
+    end
+
+    test "ignores potions until a valid placement" do
+      assert %Simulation{alchemist: %{position: %{north: 1, east: 4}, facing: :west}} =
+               Wizard.cast_spell([:move, {:place, [north: 1, east: 4, facing: :west]}])
+    end
+
+    test "with a move potion returns a simulation with the moved alchemist" do
+      assert %Simulation{alchemist: %{position: %{north: 1, east: 3}, facing: :west}} =
+               Wizard.cast_spell([{:place, [north: 1, east: 4, facing: :west]}, :move])
+    end
+
+    test "ignores any moves above the north boundary" do
+      assert %Simulation{alchemist: %{position: %{north: 4, east: 3}, facing: :north}} =
+               Wizard.cast_spell([{:place, [north: 4, east: 3, facing: :north]}, :move])
+    end
+
+    test "ignores any moves above the east boundary" do
+      assert %Simulation{alchemist: %{position: %{north: 2, east: 4}, facing: :east}} =
+               Wizard.cast_spell([{:place, [north: 2, east: 4, facing: :east]}, :move])
+    end
+
+    test "ignores any moves above the south boundary" do
+      assert %Simulation{alchemist: %{position: %{north: 0, east: 1}, facing: :south}} =
+               Wizard.cast_spell([{:place, [north: 0, east: 1, facing: :south]}, :move])
+    end
+
+    test "ignores any moves above the west boundary" do
+      assert %Simulation{alchemist: %{position: %{north: 1, east: 0}, facing: :west}} =
+               Wizard.cast_spell([{:place, [north: 1, east: 0, facing: :west]}, :move])
+    end
+
+    test "with a turn left potion returns a simulation with the turned alchemist" do
+      assert %Simulation{alchemist: %{position: %{north: 1, east: 3}, facing: :west}} =
+               Wizard.cast_spell([{:place, [north: 1, east: 3, facing: :north]}, :turn_left])
+    end
+
+    test "with a turn right potion returns a simulation with the turned alchemist" do
+      assert %Simulation{alchemist: %{position: %{north: 1, east: 3}, facing: :east}} =
+               Wizard.cast_spell([{:place, [north: 1, east: 3, facing: :north]}, :turn_right])
+    end
+
+    test "with a report potion returns a simulation with the alchemist in the same place" do
+      capture_io(fn ->
+        assert %Simulation{alchemist: %{position: %{north: 1, east: 3}, facing: :south}} =
+                 Wizard.cast_spell([{:place, [north: 1, east: 3, facing: :south]}, :report])
+      end)
+    end
+
+    test "with a report potion it reports the alchemist current position" do
+      potions = [
+        {:place, [north: 1, east: 3, facing: :south]},
+        :turn_left,
+        :move,
+        :report,
+        :turn_right
+      ]
+
+      report =
+        capture_io(fn ->
+          Wizard.cast_spell(potions)
+        end)
+
+      assert report == "The alchemist is at (1, 4) and facing EAST\n"
+    end
+
+    test "with an invalid potion ignores the potion returns the simulation" do
+      assert %Simulation{alchemist: %{position: %{north: 1, east: 3}, facing: :north}} =
+               Wizard.cast_spell([
+                 {:place, [north: 1, east: 3, facing: :north]},
+                 :turn_right,
+                 {:invalid, :blah},
+                 :turn_left
+               ])
+    end
+  end
+end


### PR DESCRIPTION
The `Wizard` uses the `Alchemist`'s potions in order to `cast_spell/1`s within a `Simulation`.

The wizard enumerates over the potions and performs those actions within the simulation. It ignores invalid potions, invalid moves, and does not start casting spells until a valid `PLACE` potion is retrieved.
